### PR TITLE
yaml requires space between the key and value

### DIFF
--- a/src/pages/vulcanlib.soy
+++ b/src/pages/vulcanlib.soy
@@ -1,7 +1,7 @@
 ---
 title: "Vulcan JLib"
 description: "Something nice and compelling about the project. Make it short and sweet."
-hidden:true
+hidden: true
 ---
 
 {namespace pageVulcanLib}


### PR DESCRIPTION
/cc @zenorocha

Hey @JorgeFerrer, this fixes the yaml error you were running into. I'll see if I can get electric to log something more helpful when the frontmatter is malformed.